### PR TITLE
Resolves #106 - Fixes File Type Description

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,8 +32,8 @@ dependencies {
 }
 
 intellij {
-  version 'LATEST-EAP-SNAPSHOT'
-  //version = '2021.2'
+  //version 'LATEST-EAP-SNAPSHOT'
+  version = '2021.2'
 }
 
 
@@ -106,13 +106,13 @@ patchPluginXml {
   <h3>v0.1.1</h3>
   <ul>
     <li>Added support for IntelliJ 2018.3.</li>
-  </ul>      
+  </ul>
   <h3>v0.1.0</h3>
   <ul>
     <li>Initial Release.</li>
   </ul>
 """
-  sinceBuild = '211.0'
+  sinceBuild = '212.0'
   untilBuild = '221.0'
 }
 

--- a/src/main/java/net/sjrx/intellij/plugins/systemdunitfiles/filetypes/AbstractUnitFileType.java
+++ b/src/main/java/net/sjrx/intellij/plugins/systemdunitfiles/filetypes/AbstractUnitFileType.java
@@ -1,0 +1,22 @@
+package net.sjrx.intellij.plugins.systemdunitfiles.filetypes;
+
+import com.intellij.lang.Language;
+import com.intellij.openapi.fileTypes.LanguageFileType;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NotNull;
+
+public abstract class AbstractUnitFileType extends LanguageFileType {
+
+  protected AbstractUnitFileType(@NotNull Language language) {
+    super(language);
+  }
+  
+  protected AbstractUnitFileType(@NotNull Language language, boolean secondary) {
+    super(language, secondary);
+  }
+  
+  @Nls
+  @Override
+  public abstract @NotNull String getDisplayName();
+  
+}

--- a/src/main/java/net/sjrx/intellij/plugins/systemdunitfiles/filetypes/AutomountFileType.java
+++ b/src/main/java/net/sjrx/intellij/plugins/systemdunitfiles/filetypes/AutomountFileType.java
@@ -1,14 +1,14 @@
 package net.sjrx.intellij.plugins.systemdunitfiles.filetypes;
 
-import com.intellij.openapi.fileTypes.LanguageFileType;
 import net.sjrx.intellij.plugins.systemdunitfiles.UnitFileIcon;
 import net.sjrx.intellij.plugins.systemdunitfiles.UnitFileLanguage;
+import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.Icon;
 
-public class AutomountFileType extends LanguageFileType {
+public class AutomountFileType extends AbstractUnitFileType {
   public static final AutomountFileType INSTANCE = new AutomountFileType();
 
   private AutomountFileType() {
@@ -24,8 +24,7 @@ public class AutomountFileType extends LanguageFileType {
   @NotNull
   @Override
   public String getDescription() {
-    return "A unit configuration file whose name ends in \".automount\" encodes information about a file system automount point "
-           + "controlled and supervised by systemd.";
+    return getDisplayName();
   }
 
   @NotNull
@@ -38,5 +37,11 @@ public class AutomountFileType extends LanguageFileType {
   @Override
   public Icon getIcon() {
     return UnitFileIcon.FILE;
+  }
+  
+  @Nls
+  @Override
+  public @NotNull String getDisplayName() {
+    return "Automount unit configuration (systemd)";
   }
 }

--- a/src/main/java/net/sjrx/intellij/plugins/systemdunitfiles/filetypes/DeviceFileType.java
+++ b/src/main/java/net/sjrx/intellij/plugins/systemdunitfiles/filetypes/DeviceFileType.java
@@ -1,14 +1,14 @@
 package net.sjrx.intellij.plugins.systemdunitfiles.filetypes;
 
-import com.intellij.openapi.fileTypes.LanguageFileType;
 import net.sjrx.intellij.plugins.systemdunitfiles.UnitFileIcon;
 import net.sjrx.intellij.plugins.systemdunitfiles.UnitFileLanguage;
+import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.Icon;
 
-public class DeviceFileType extends LanguageFileType {
+public class DeviceFileType extends AbstractUnitFileType {
   public static final DeviceFileType INSTANCE = new DeviceFileType();
 
   private DeviceFileType() {
@@ -24,8 +24,7 @@ public class DeviceFileType extends LanguageFileType {
   @NotNull
   @Override
   public String getDescription() {
-    return "A unit configuration file whose name ends in \".device\" encodes information about a device unit as exposed in the "
-           + "sysfs/udev(7) device tree.";
+    return getDisplayName();
   }
 
   @NotNull
@@ -38,5 +37,11 @@ public class DeviceFileType extends LanguageFileType {
   @Override
   public Icon getIcon() {
     return UnitFileIcon.FILE;
+  }
+  
+  @Nls
+  @Override
+  public @NotNull String getDisplayName() {
+    return "Device unit configuration (systemd)";
   }
 }

--- a/src/main/java/net/sjrx/intellij/plugins/systemdunitfiles/filetypes/MountFileType.java
+++ b/src/main/java/net/sjrx/intellij/plugins/systemdunitfiles/filetypes/MountFileType.java
@@ -1,14 +1,14 @@
 package net.sjrx.intellij.plugins.systemdunitfiles.filetypes;
 
-import com.intellij.openapi.fileTypes.LanguageFileType;
 import net.sjrx.intellij.plugins.systemdunitfiles.UnitFileIcon;
 import net.sjrx.intellij.plugins.systemdunitfiles.UnitFileLanguage;
+import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.Icon;
 
-public class MountFileType extends LanguageFileType {
+public class MountFileType extends AbstractUnitFileType {
   public static final MountFileType INSTANCE = new MountFileType();
 
   private MountFileType() {
@@ -24,8 +24,7 @@ public class MountFileType extends LanguageFileType {
   @NotNull
   @Override
   public String getDescription() {
-    return "A unit configuration file whose name ends in \".mount\" encodes information about a file system mount "
-           + "point controlled and supervised by systemd.";
+    return getDisplayName();
   }
 
   @NotNull
@@ -38,5 +37,11 @@ public class MountFileType extends LanguageFileType {
   @Override
   public Icon getIcon() {
     return UnitFileIcon.FILE;
+  }
+  
+  @Nls
+  @Override
+  public @NotNull String getDisplayName() {
+    return "Mount unit configuration (systemd)";
   }
 }

--- a/src/main/java/net/sjrx/intellij/plugins/systemdunitfiles/filetypes/PathFileType.java
+++ b/src/main/java/net/sjrx/intellij/plugins/systemdunitfiles/filetypes/PathFileType.java
@@ -1,14 +1,14 @@
 package net.sjrx.intellij.plugins.systemdunitfiles.filetypes;
 
-import com.intellij.openapi.fileTypes.LanguageFileType;
 import net.sjrx.intellij.plugins.systemdunitfiles.UnitFileIcon;
 import net.sjrx.intellij.plugins.systemdunitfiles.UnitFileLanguage;
+import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.Icon;
 
-public class PathFileType extends LanguageFileType {
+public class PathFileType extends AbstractUnitFileType {
   public static final PathFileType INSTANCE = new PathFileType();
 
   private PathFileType() {
@@ -24,8 +24,7 @@ public class PathFileType extends LanguageFileType {
   @NotNull
   @Override
   public String getDescription() {
-    return "A unit configuration file whose name ends in \".path\" encodes information about a path monitored by systemd,"
-           + " for path-based activation.";
+    return getDisplayName();
   }
 
   @NotNull
@@ -38,5 +37,11 @@ public class PathFileType extends LanguageFileType {
   @Override
   public Icon getIcon() {
     return UnitFileIcon.FILE;
+  }
+  
+  @Nls
+  @Override
+  public @NotNull String getDisplayName() {
+    return "Path unit configuration (systemd)";
   }
 }

--- a/src/main/java/net/sjrx/intellij/plugins/systemdunitfiles/filetypes/ServiceFileType.java
+++ b/src/main/java/net/sjrx/intellij/plugins/systemdunitfiles/filetypes/ServiceFileType.java
@@ -1,14 +1,14 @@
 package net.sjrx.intellij.plugins.systemdunitfiles.filetypes;
 
-import com.intellij.openapi.fileTypes.LanguageFileType;
 import net.sjrx.intellij.plugins.systemdunitfiles.UnitFileIcon;
 import net.sjrx.intellij.plugins.systemdunitfiles.UnitFileLanguage;
+import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.Icon;
 
-public class ServiceFileType extends LanguageFileType {
+public class ServiceFileType extends AbstractUnitFileType {
   public static final ServiceFileType INSTANCE = new ServiceFileType();
 
   private ServiceFileType() {
@@ -24,8 +24,7 @@ public class ServiceFileType extends LanguageFileType {
   @NotNull
   @Override
   public String getDescription() {
-    return "A unit configuration file whose name ends in \".service\" encodes information about a process controlled and supervised "
-           + "by systemd.";
+    return getDisplayName();
   }
 
   @NotNull
@@ -38,5 +37,11 @@ public class ServiceFileType extends LanguageFileType {
   @Override
   public Icon getIcon() {
     return UnitFileIcon.FILE;
+  }
+  
+  @Nls
+  @Override
+  public @NotNull String getDisplayName() {
+    return "Service unit configuration (systemd)";
   }
 }

--- a/src/main/java/net/sjrx/intellij/plugins/systemdunitfiles/filetypes/SliceFileType.java
+++ b/src/main/java/net/sjrx/intellij/plugins/systemdunitfiles/filetypes/SliceFileType.java
@@ -1,14 +1,14 @@
 package net.sjrx.intellij.plugins.systemdunitfiles.filetypes;
 
-import com.intellij.openapi.fileTypes.LanguageFileType;
 import net.sjrx.intellij.plugins.systemdunitfiles.UnitFileIcon;
 import net.sjrx.intellij.plugins.systemdunitfiles.UnitFileLanguage;
+import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.Icon;
 
-public class SliceFileType extends LanguageFileType {
+public class SliceFileType extends AbstractUnitFileType {
   public static final SliceFileType INSTANCE = new SliceFileType();
 
   private SliceFileType() {
@@ -24,14 +24,7 @@ public class SliceFileType extends LanguageFileType {
   @NotNull
   @Override
   public String getDescription() {
-    return "A unit configuration file whose name ends in \".slice\" encodes information about a slice unit. A slice unit "
-           + "is a concept for hierarchically managing resources of a group of processes. This management is performed by creating a "
-           + "node in the Linux Control Group (cgroup) tree. Units that manage processes (primarily scope and service units) may be "
-           + "assigned to a specific slice. For each slice, certain resource limits may be set that apply to all processes of all "
-           + "units contained in that slice. Slices are organized hierarchically in a tree. The name of the slice encodes the location "
-           + "in the tree. The name consists of a dash-separated series of names, which describes the path to the slice from the root "
-           + "slice. The root slice is named -.slice. Example: foo-bar.slice is a slice that is located within foo.slice, which in "
-           + "turn is located in the root slice -.slice.";
+    return getDisplayName();
   }
 
   @NotNull
@@ -44,5 +37,11 @@ public class SliceFileType extends LanguageFileType {
   @Override
   public Icon getIcon() {
     return UnitFileIcon.FILE;
+  }
+  
+  @Nls
+  @Override
+  public @NotNull String getDisplayName() {
+    return "Slice unit configuration (systemd)";
   }
 }

--- a/src/main/java/net/sjrx/intellij/plugins/systemdunitfiles/filetypes/SocketFileType.java
+++ b/src/main/java/net/sjrx/intellij/plugins/systemdunitfiles/filetypes/SocketFileType.java
@@ -1,14 +1,14 @@
 package net.sjrx.intellij.plugins.systemdunitfiles.filetypes;
 
-import com.intellij.openapi.fileTypes.LanguageFileType;
 import net.sjrx.intellij.plugins.systemdunitfiles.UnitFileIcon;
 import net.sjrx.intellij.plugins.systemdunitfiles.UnitFileLanguage;
+import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.Icon;
 
-public class SocketFileType extends LanguageFileType {
+public class SocketFileType extends AbstractUnitFileType {
   public static final SocketFileType INSTANCE = new SocketFileType();
 
   private SocketFileType() {
@@ -24,8 +24,7 @@ public class SocketFileType extends LanguageFileType {
   @NotNull
   @Override
   public String getDescription() {
-    return "A unit configuration file whose name ends in \".socket\" encodes information about an IPC or network socket or a file "
-           + "system FIFO controlled and supervised by systemd, for socket-based activation.";
+    return getDisplayName();
   }
 
   @NotNull
@@ -38,5 +37,11 @@ public class SocketFileType extends LanguageFileType {
   @Override
   public Icon getIcon() {
     return UnitFileIcon.FILE;
+  }
+  
+  @Nls
+  @Override
+  public @NotNull String getDisplayName() {
+    return "Socket unit configuration (systemd)";
   }
 }

--- a/src/main/java/net/sjrx/intellij/plugins/systemdunitfiles/filetypes/SwapFileType.java
+++ b/src/main/java/net/sjrx/intellij/plugins/systemdunitfiles/filetypes/SwapFileType.java
@@ -1,14 +1,14 @@
 package net.sjrx.intellij.plugins.systemdunitfiles.filetypes;
 
-import com.intellij.openapi.fileTypes.LanguageFileType;
 import net.sjrx.intellij.plugins.systemdunitfiles.UnitFileIcon;
 import net.sjrx.intellij.plugins.systemdunitfiles.UnitFileLanguage;
+import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.Icon;
 
-public class SwapFileType extends LanguageFileType {
+public class SwapFileType extends AbstractUnitFileType {
   public static final SwapFileType INSTANCE = new SwapFileType();
 
   private SwapFileType() {
@@ -24,8 +24,7 @@ public class SwapFileType extends LanguageFileType {
   @NotNull
   @Override
   public String getDescription() {
-    return "A unit configuration file whose name ends in \".swap\" encodes information about a swap device or file for memory"
-           + " paging controlled and supervised by systemd.";
+    return getDisplayName();
   }
 
   @NotNull
@@ -38,5 +37,11 @@ public class SwapFileType extends LanguageFileType {
   @Override
   public Icon getIcon() {
     return UnitFileIcon.FILE;
+  }
+  
+  @Nls
+  @Override
+  public @NotNull String getDisplayName() {
+    return "Swap unit configuration (systemd)";
   }
 }

--- a/src/main/java/net/sjrx/intellij/plugins/systemdunitfiles/filetypes/TargetFileType.java
+++ b/src/main/java/net/sjrx/intellij/plugins/systemdunitfiles/filetypes/TargetFileType.java
@@ -1,14 +1,14 @@
 package net.sjrx.intellij.plugins.systemdunitfiles.filetypes;
 
-import com.intellij.openapi.fileTypes.LanguageFileType;
 import net.sjrx.intellij.plugins.systemdunitfiles.UnitFileIcon;
 import net.sjrx.intellij.plugins.systemdunitfiles.UnitFileLanguage;
+import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.Icon;
 
-public class TargetFileType extends LanguageFileType {
+public class TargetFileType extends AbstractUnitFileType {
   public static final TargetFileType INSTANCE = new TargetFileType();
 
   private TargetFileType() {
@@ -24,8 +24,7 @@ public class TargetFileType extends LanguageFileType {
   @NotNull
   @Override
   public String getDescription() {
-    return "A unit configuration file whose name ends in \".target\" encodes information about a target unit of systemd, which is used "
-           + "for grouping units and as well-known synchronization points during start-up.";
+    return getDisplayName();
   }
 
   @NotNull
@@ -38,5 +37,11 @@ public class TargetFileType extends LanguageFileType {
   @Override
   public Icon getIcon() {
     return UnitFileIcon.FILE;
+  }
+  
+  @Nls
+  @Override
+  public @NotNull String getDisplayName() {
+    return "Target unit configuration (systemd)";
   }
 }

--- a/src/main/java/net/sjrx/intellij/plugins/systemdunitfiles/filetypes/TimerFileType.java
+++ b/src/main/java/net/sjrx/intellij/plugins/systemdunitfiles/filetypes/TimerFileType.java
@@ -1,14 +1,14 @@
 package net.sjrx.intellij.plugins.systemdunitfiles.filetypes;
 
-import com.intellij.openapi.fileTypes.LanguageFileType;
 import net.sjrx.intellij.plugins.systemdunitfiles.UnitFileIcon;
 import net.sjrx.intellij.plugins.systemdunitfiles.UnitFileLanguage;
+import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.Icon;
 
-public class TimerFileType extends LanguageFileType {
+public class TimerFileType extends AbstractUnitFileType {
   public static final TimerFileType INSTANCE = new TimerFileType();
 
   private TimerFileType() {
@@ -24,8 +24,7 @@ public class TimerFileType extends LanguageFileType {
   @NotNull
   @Override
   public String getDescription() {
-    return "A unit configuration file whose name ends in \".timer\" encodes information about a timer controlled and supervised by "
-           + "systemd, for timer-based activation.";
+    return getDisplayName();
   }
 
   @NotNull
@@ -38,5 +37,11 @@ public class TimerFileType extends LanguageFileType {
   @Override
   public Icon getIcon() {
     return UnitFileIcon.FILE;
+  }
+  
+  @Nls
+  @Override
+  public @NotNull String getDisplayName() {
+    return "Timer unit configuration (systemd)";
   }
 }


### PR DESCRIPTION
*Note*: At this time I've set the DisplayName and Description to be the same, which seems to be what most other plugins are doing. Unsure of when the DisplayName is actually used.

Also upgrades minimum version to 2021.2 since the Plugin Verifier only runs against that version (probably configuration error, but was too lazy to investigate).