### PR TITLE
Revert "Speedup UnitDependencyOptionValue completion "

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -30,7 +30,7 @@
   <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
 
   <!-- Gradle ignores this value -->
-  <idea-version since-build="223.0"/>
+  <idea-version since-build="182.0"/>
   <!-- Gradle ignores this value -->
 
   <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html

--- a/systemd-build/ubuntu-units.sh
+++ b/systemd-build/ubuntu-units.sh
@@ -2,8 +2,5 @@
 
 for type in service socket device mount automount swap target path timer slice scope
 do
-  echo "Processing extension '$type'" >&2
   apt-file search -x  "\.$type$" | grep -v example | grep "systemd"  | grep -v "/test" | sed -E "s#^.+/##g" | sort | uniq
 done
-
-echo "All done" >&2


### PR DESCRIPTION
Reverts SJrX/systemdUnitFilePlugin#232

Hey @VladRassokhin 

I think I need to revert this MR, JetBrains has rejected the release, I believe because of this:

https://github.com/SJrX/systemdUnitFilePlugin/pull/232/files#diff-591e7f8462f95e8ff6c535d6005073af9eb7be1a9992314f13acf14b09413338R119

Although I guess I'm not sure if it's exactly that. The report I got was : 

> The [latest update of your plugin](https://plugins.jetbrains.com/plugin/11070-unit-file-support-systemd-/edit/versions/stable/475957) uses API annotated with org.jetbrains.annotations.ApiStatus.Internal. Such APIs are private and cannot be used outside the IntelliJ Platform itself.

I'm not 100% sure I will revert it, but it will be a bit before I can look at this. So I wanted to give you a heads up.