### PR TITLE
Add support for notify-reload in service Type

### DIFF
--- a/src/main/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/annotators/PidFileOptionWarning.kt
+++ b/src/main/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/annotators/PidFileOptionWarning.kt
@@ -20,6 +20,6 @@ class PidFileOptionWarning : Annotator {
   }
 
     companion object {
-      const val ANNOTATION_ERROR_MSG = "PID files should be avoided in modern projects. Use type=notify, Type=notify-release or Type=simple  where possible, which does not require use of PID files to determine the main process of a service and avoids needless forking."
+      const val ANNOTATION_ERROR_MSG = "PID files should be avoided in modern projects. Use Type=notify, Type=notify-reload or Type=simple where possible, which does not require use of PID files to determine the main process of a service and avoids needless forking."
     }
 }

--- a/src/main/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/semanticdata/optionvalues/EnumOptionValues.kt
+++ b/src/main/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/semanticdata/optionvalues/EnumOptionValues.kt
@@ -40,7 +40,7 @@ class RestartOptionValue : AbstractEnumOptionValue(validOptions, VALIDATOR_NAME)
 class ServiceTypeOptionValue : AbstractEnumOptionValue(validOptions, VALIDATOR_NAME) {
 
   companion object {
-    private val validOptions: Set<String> = ImmutableSet.of("simple", "forking", "oneshot", "dbus", "notify", "idle", "exec")
+    private val validOptions: Set<String> = ImmutableSet.of("simple", "forking", "oneshot", "dbus", "notify", "notify-reload", "idle", "exec")
     const val VALIDATOR_NAME = "config_parse_service_type"
   }
 }

--- a/src/test/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/completion/UnitFileValueCompletionContributorTest.kt
+++ b/src/test/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/completion/UnitFileValueCompletionContributorTest.kt
@@ -92,7 +92,7 @@ class UnitFileValueCompletionContributorTest : AbstractUnitFileTest() {
     val completions = basicCompletionResultStrings
 
     // Verification
-    assertContainsElements(completions, "forking", "oneshot", "notify")
+    assertContainsElements(completions, "forking", "oneshot", "notify", "notify-reload")
   }
 
   fun testCompletionOfUnitDependencyIncludesUnitsInFilename() {

--- a/src/test/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/inspections/InvalidValueInspectionForEnumOptionValueTests.kt
+++ b/src/test/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/inspections/InvalidValueInspectionForEnumOptionValueTests.kt
@@ -380,6 +380,7 @@ class InvalidValueInspectionForServiceTypeOptionValues : AbstractUnitFileTest() 
            Type=oneshot
            Type=dbus
            Type=notify
+           Type=notify-reload
            Type=idle
            Type=exec
            
@@ -423,6 +424,7 @@ class InvalidValueInspectionForServiceTypeOptionValues : AbstractUnitFileTest() 
     assertStringContains("oneshot", info.description)
     assertStringContains("dbus", info.description)
     assertStringContains("notify", info.description)
+    assertStringContains("notify-reload", info.description)
     assertStringContains("idle", info.description)
     assertStringContains("exec", info.description)
     TestCase.assertEquals(HighlightInfoType.WARNING, info.type)
@@ -453,6 +455,7 @@ class InvalidValueInspectionForServiceTypeOptionValues : AbstractUnitFileTest() 
     assertStringContains("oneshot", info.description)
     assertStringContains("dbus", info.description)
     assertStringContains("notify", info.description)
+    assertStringContains("notify-reload", info.description)
     assertStringContains("idle", info.description)
     assertStringContains("exec", info.description)
     TestCase.assertEquals(HighlightInfoType.WARNING, info.type)


### PR DESCRIPTION
Adds the new Type to plugin code and tests. If there is any place I missed where it should be added, let me know.

The [example.service.ft](https://github.com/SJrX/systemdUnitFilePlugin/blob/ff22f3f91676900fc8c79c16d7076aadc17a42b4/src/main/resources/fileTemplates/internal/example.service.ft) template is lacking some of the service types, including notify, but they are there for documentation purposes. Should we add them there?

Fixes #263 