### PR TITLE
fix: Don't warn if notify-reload is used as a Type= in service.

### DIFF
--- a/src/main/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/annotators/PidFileOptionWarning.kt
+++ b/src/main/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/annotators/PidFileOptionWarning.kt
@@ -20,6 +20,6 @@ class PidFileOptionWarning : Annotator {
   }
 
     companion object {
-      const val ANNOTATION_ERROR_MSG = "PID files should be avoided in modern projects. Use type=notify, Type=notify-release or Type=simple  where possible, which does not require use of PID files to determine the main process of a service and avoids needless forking."
+      const val ANNOTATION_ERROR_MSG = "PID files should be avoided in modern projects. Use Type=notify, Type=notify-reload or Type=simple where possible, which does not require use of PID files to determine the main process of a service and avoids needless forking."
     }
 }

--- a/src/main/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/semanticdata/optionvalues/EnumOptionValues.kt
+++ b/src/main/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/semanticdata/optionvalues/EnumOptionValues.kt
@@ -40,7 +40,7 @@ class RestartOptionValue : AbstractEnumOptionValue(validOptions, VALIDATOR_NAME)
 class ServiceTypeOptionValue : AbstractEnumOptionValue(validOptions, VALIDATOR_NAME) {
 
   companion object {
-    private val validOptions: Set<String> = ImmutableSet.of("simple", "forking", "oneshot", "dbus", "notify", "idle", "exec")
+    private val validOptions: Set<String> = ImmutableSet.of("simple", "forking", "oneshot", "dbus", "notify", "notify-reload", "idle", "exec")
     const val VALIDATOR_NAME = "config_parse_service_type"
   }
 }

--- a/src/test/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/completion/UnitFileValueCompletionContributorTest.kt
+++ b/src/test/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/completion/UnitFileValueCompletionContributorTest.kt
@@ -92,7 +92,7 @@ class UnitFileValueCompletionContributorTest : AbstractUnitFileTest() {
     val completions = basicCompletionResultStrings
 
     // Verification
-    assertContainsElements(completions, "forking", "oneshot", "notify")
+    assertContainsElements(completions, "forking", "oneshot", "notify", "notify-reload")
   }
 
   fun testCompletionOfUnitDependencyIncludesUnitsInFilename() {

--- a/src/test/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/inspections/InvalidValueInspectionForEnumOptionValueTests.kt
+++ b/src/test/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/inspections/InvalidValueInspectionForEnumOptionValueTests.kt
@@ -380,6 +380,7 @@ class InvalidValueInspectionForServiceTypeOptionValues : AbstractUnitFileTest() 
            Type=oneshot
            Type=dbus
            Type=notify
+           Type=notify-reload
            Type=idle
            Type=exec
            
@@ -423,6 +424,7 @@ class InvalidValueInspectionForServiceTypeOptionValues : AbstractUnitFileTest() 
     assertStringContains("oneshot", info.description)
     assertStringContains("dbus", info.description)
     assertStringContains("notify", info.description)
+    assertStringContains("notify-reload", info.description)
     assertStringContains("idle", info.description)
     assertStringContains("exec", info.description)
     TestCase.assertEquals(HighlightInfoType.WARNING, info.type)
@@ -453,6 +455,7 @@ class InvalidValueInspectionForServiceTypeOptionValues : AbstractUnitFileTest() 
     assertStringContains("oneshot", info.description)
     assertStringContains("dbus", info.description)
     assertStringContains("notify", info.description)
+    assertStringContains("notify-reload", info.description)
     assertStringContains("idle", info.description)
     assertStringContains("exec", info.description)
     TestCase.assertEquals(HighlightInfoType.WARNING, info.type)


### PR DESCRIPTION
* Adds notify-reload service Type

Fixes SJrX/systemdUnitFilePlugin#263

* Update test InvalidValueInspectionForEnumOptionValueTests.kt with notify-reload service Type

* Adds notify-reload to completion test for service Type=o...

* Update PidFileOptionWarning.kt annotation msg to reflect current systemd docs

While searching for "notify" throughout the repo to add notify-reload support, I noticed this message which mentioned notify and notify-release.

This might be from a previous version of systemd, but the docs now mention notify-reload instead of notify-release, so I updated it to be consistent with the addition of notify-release mode to the plugin.