### PR TITLE
fix: make generateDataFromManPages work under Gradle 9

### DIFF
--- a/buildSrc/src/main/groovy/GenerateDataFromManPages.groovy
+++ b/buildSrc/src/main/groovy/GenerateDataFromManPages.groovy
@@ -436,7 +436,7 @@ class GenerateDataFromManPages extends DefaultTask {
 
 
     Document document = buildDocumentProcessingIncludes(sourceFile)
-    Transformer transformer = getXsltTransformer()
+    Transformer transformer = createXsltTransformer()
 
     String xsltOutput = transformDocument(document, transformer)
 
@@ -597,7 +597,7 @@ class GenerateDataFromManPages extends DefaultTask {
    *
    * @return a Transformer instance configured with the XSLT
    */
-  private Transformer getXsltTransformer() {
+  protected Transformer createXsltTransformer() {
 
     StreamSource styleSource = new StreamSource(this.getClass().getClassLoader().getResourceAsStream("transformManPages.xslt"))
 


### PR DESCRIPTION
## What

Renames the private \`getXsltTransformer()\` helper in \`GenerateDataFromManPages\` to \`protected createXsltTransformer()\`.

## Why

On \`242.x\` (Gradle 9.5.1), \`./gradlew test\` fails because its \`generateDataFromManPages\` dependency errors at execution time:

\`\`\`
Could not find method getXsltTransformer() for arguments [] on task
':generateDataFromManPages' of type GenerateDataFromManPages.
\`\`\`

Under Gradle 9's task decoration, a \`get\`-prefixed method on a task is treated as a **property getter**, so the direct call \`getXsltTransformer()\` can no longer be resolved as a method via Groovy dynamic dispatch. Renaming it away from the \`get\` prefix (and making it \`protected\`, matching the sibling helpers \`transformDocument\`/\`buildDocumentProcessingIncludes\`) restores the call. No behavioral change.

## Verification

With this change, \`./gradlew test\` runs to completion (previously it could not even reach the test task).

🤖 Generated with [Claude Code](https://claude.com/claude-code)