### PR TITLE
feat: chain through forced separators in grammar completion (#467 #343)

### DIFF
--- a/src/main/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/completion/UnitFileValueCompletionContributor.kt
+++ b/src/main/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/completion/UnitFileValueCompletionContributor.kt
@@ -1,6 +1,8 @@
 package net.sjrx.intellij.plugins.systemdunitfiles.completion
 
+import com.intellij.codeInsight.AutoPopupController
 import com.intellij.codeInsight.completion.*
+import com.intellij.codeInsight.lookup.LookupElement
 import com.intellij.codeInsight.lookup.LookupElementBuilder
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.patterns.PlatformPatterns
@@ -12,6 +14,7 @@ import net.sjrx.intellij.plugins.systemdunitfiles.psi.UnitFileProperty
 import net.sjrx.intellij.plugins.systemdunitfiles.psi.UnitFileSectionGroups
 import net.sjrx.intellij.plugins.systemdunitfiles.semanticdata.SemanticDataRepository
 import net.sjrx.intellij.plugins.systemdunitfiles.semanticdata.fileClass
+import net.sjrx.intellij.plugins.systemdunitfiles.semanticdata.optionvalues.grammar.Combinator
 import net.sjrx.intellij.plugins.systemdunitfiles.semanticdata.optionvalues.grammar.GrammarOptionValue
 import net.sjrx.intellij.plugins.systemdunitfiles.semanticdata.optionvalues.grammar.nextTokenChoices
 import net.sjrx.intellij.plugins.systemdunitfiles.settings.ExperimentalSettings
@@ -100,7 +103,7 @@ class UnitFileValueCompletionContributor : CompletionContributor() {
       val word = pre.substring(split)
       val choices = combinator.nextTokenChoices(pre.substring(0, split))
       if (choices.any { it.length > word.length && it.startsWith(word) }) {
-        resultSet.withPrefixMatcher(word).addAllElements(choices.map { LookupElementBuilder.create(it) })
+        resultSet.withPrefixMatcher(word).addAllElements(lookupElements(choices, combinator))
         return
       }
     }
@@ -110,7 +113,40 @@ class UnitFileValueCompletionContributor : CompletionContributor() {
     ProgressManager.checkCanceled()
     val choices = combinator.nextTokenChoices(pre)
     if (choices.isNotEmpty()) {
-      resultSet.withPrefixMatcher("").addAllElements(choices.map { LookupElementBuilder.create(it) })
+      resultSet.withPrefixMatcher("").addAllElements(lookupElements(choices, combinator))
     }
+  }
+
+  private fun lookupElements(choices: Set<String>, combinator: Combinator): List<LookupElement> {
+    val handler = chainingInsertHandler(combinator)
+    return choices.map { LookupElementBuilder.create(it).withInsertHandler(handler) }
+  }
+
+  /**
+   * After a choice is accepted, walk the grammar forward: while the only thing it can accept next is
+   * a single forced separator (punctuation, e.g. "=" after a partition designator), insert it
+   * automatically, then re-open completion. So accepting "home" yields "home=" with the policy-flag
+   * popup, rather than stopping on a separator the user must type by hand.
+   */
+  private fun chainingInsertHandler(combinator: Combinator) = InsertHandler<LookupElement> { context, _ ->
+    context.commitDocument()
+    val element = context.file.findElementAt(maxOf(0, context.tailOffset - 1)) ?: return@InsertHandler
+    val property = PsiTreeUtil.getParentOfType(element, UnitFileProperty::class.java) ?: return@InsertHandler
+    val valueStart = property.valueNode?.psi?.textRange?.startOffset ?: return@InsertHandler
+    val document = context.document
+
+    var caret = context.tailOffset
+    var guard = 0
+    while (guard++ < 8 && caret in valueStart..document.textLength) {
+      val pre = document.charsSequence.subSequence(valueStart, caret).toString()
+      val separator = combinator.nextTokenChoices(pre).singleOrNull() ?: break
+      // Only auto-insert a forced punctuation separator; never a content token the user should pick.
+      if (separator.isEmpty() || separator.any { it.isLetterOrDigit() }) break
+      document.insertString(caret, separator)
+      caret += separator.length
+    }
+    context.commitDocument()
+    context.editor.caretModel.moveToOffset(caret)
+    AutoPopupController.getInstance(context.project).scheduleAutoPopup(context.editor)
   }
 }

--- a/src/test/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/completion/ImagePolicyCompletionTest.kt
+++ b/src/test/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/completion/ImagePolicyCompletionTest.kt
@@ -45,4 +45,14 @@ class ImagePolicyCompletionTest : AbstractUnitFileTest() {
     setupFileInEditor("file.service", "[Service]\nRootImagePolicy=root=${COMPLETION_POSITION}")
     assertContainsElements(basicCompletionResultStrings, "verity", "signed", "encrypted")
   }
+
+  @Test
+  fun testAcceptingPartitionChainsTheEqualsSeparator() {
+    // Accepting a partition designator auto-inserts the forced "=" (then re-opens completion),
+    // so the user goes straight to choosing a policy flag.
+    enableNewEngine()
+    setupFileInEditor("file.service", "[Service]\nRootImagePolicy=hom${COMPLETION_POSITION}")
+    myFixture.completeBasic() // single match "home" -> auto-inserted -> handler appends "="
+    myFixture.checkResult("[Service]\nRootImagePolicy=home=${COMPLETION_POSITION}")
+  }
 }


### PR DESCRIPTION
## What

Implements "option 1" from the discussion: when you accept a grammar completion, if the only thing the grammar can accept next is a **forced separator**, it's auto-inserted and completion re-opens. So accepting `home` gives you `home=` with the policy-flag popup immediately, instead of stopping on a lone `=` you'd have to type yourself.

> Stacked on #477 (`issue-345-8`).

## Why

After a complete partition designator like `home`, the grammar allows exactly one next token: `=`. A completion popup whose only entry is a single punctuation separator is low-value — and the platform won't even autopopup it (you'd need Ctrl+Space). What the user actually wants next is the *policy flag*. Chaining through the separator gets them there in one motion (mirrors how method completion inserts `()`).

## How

`chainingInsertHandler` runs after a choice is accepted:
1. Resolve the value start via PSI, read the value text up to the caret.
2. While `nextTokenChoices(pre)` is exactly one **punctuation** separator (no letters/digits — so `=`, `+`, `:`, never a content token like `verity`), insert it and advance. Bounded loop (≤ 8).
3. `scheduleAutoPopup` so the following real choices (flags) appear.

It only ever auto-inserts forced separators, never a content token the user should pick. Applies to all grammar-completion items, so it generalizes to other grammars (`:` in `ipv4:tcp:…`, etc.).

## Test

`testAcceptingPartitionChainsTheEqualsSeparator`: `RootImagePolicy=hom⎉` → accept the single match `home` → document becomes `RootImagePolicy=home=⎉`.

Full suite green.

Refs #467 #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)