### PR TITLE
docs: identifier example in color settings preview (#467 #342)

### DIFF
--- a/src/main/java/net/sjrx/intellij/plugins/systemdunitfiles/coloring/settings/UnitFileColorSettings.java
+++ b/src/main/java/net/sjrx/intellij/plugins/systemdunitfiles/coloring/settings/UnitFileColorSettings.java
@@ -53,7 +53,7 @@ public class UnitFileColorSettings implements ColorSettingsPage {
            + "#  (at your option) any later version.\n"
            + "\n"
            + "[Unit]\n"
-           + "Description=Reload Configuration from the Real Root\n"
+           + "Description=<gId>Reload Configuration from the Real Root</gId>\n"
            + "DefaultDependencies=no\n"
            + "Requires=initrd-root-fs.target\n"
            + "After=initrd-root-fs.target\n"


### PR DESCRIPTION
## What

The color-settings preview (*Settings → Editor → Color Scheme → Unit Files (systemd)*) had grammar examples for **enum / literal / operator**, but none for **Identifier** — so clicking "Value//Identifier (grammar)" highlighted nothing in the sample.

Tag the existing `[Unit] Description=` value with the identifier tag. `Description=` is `config_parse_unit_string_printf` → a free-form `RegexTerminal` → role `IDENTIFIER`, so it's an accurate example, and clicking the Identifier attribute now highlights it.

> Stacked on #481 (`issue-345-12`). One-line demo-text change.

Refs #467 #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)