### PR TITLE
fix: leave free-form string values at the default color (#467 #342)

### DIFF
--- a/src/main/java/net/sjrx/intellij/plugins/systemdunitfiles/coloring/settings/UnitFileColorSettings.java
+++ b/src/main/java/net/sjrx/intellij/plugins/systemdunitfiles/coloring/settings/UnitFileColorSettings.java
@@ -25,7 +25,6 @@ public class UnitFileColorSettings implements ColorSettingsPage {
     new AttributesDescriptor("Value//Enum (grammar)", UnitFileHighlighter.GRAMMAR_ENUM),
     new AttributesDescriptor("Value//Literal (grammar)", UnitFileHighlighter.GRAMMAR_LITERAL),
     new AttributesDescriptor("Value//Operator (grammar)", UnitFileHighlighter.GRAMMAR_OPERATOR),
-    new AttributesDescriptor("Value//Identifier (grammar)", UnitFileHighlighter.GRAMMAR_IDENTIFIER),
   };
 
   @Nullable
@@ -53,7 +52,7 @@ public class UnitFileColorSettings implements ColorSettingsPage {
            + "#  (at your option) any later version.\n"
            + "\n"
            + "[Unit]\n"
-           + "Description=<gId>Reload Configuration from the Real Root</gId>\n"
+           + "Description=Reload Configuration from the Real Root\n"
            + "DefaultDependencies=no\n"
            + "Requires=initrd-root-fs.target\n"
            + "After=initrd-root-fs.target\n"
@@ -81,7 +80,6 @@ public class UnitFileColorSettings implements ColorSettingsPage {
     tags.put("gEnum", UnitFileHighlighter.GRAMMAR_ENUM);
     tags.put("gLit", UnitFileHighlighter.GRAMMAR_LITERAL);
     tags.put("gOp", UnitFileHighlighter.GRAMMAR_OPERATOR);
-    tags.put("gId", UnitFileHighlighter.GRAMMAR_IDENTIFIER);
     return tags;
   }
 

--- a/src/main/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/semanticdata/optionvalues/grammar/Coloring.kt
+++ b/src/main/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/semanticdata/optionvalues/grammar/Coloring.kt
@@ -37,8 +37,10 @@ fun defaultRole(terminal: TerminalCombinator): Role? = when (terminal) {
   is IntegerTerminal -> Role.LITERAL
   is LiteralChoiceTerminal -> if (terminal.choices.allPunctuation()) Role.OPERATOR else Role.ENUM
   is FlexibleLiteralChoiceTerminal -> if (terminal.choices.allPunctuation()) Role.OPERATOR else Role.ENUM
-  is RegexTerminal -> Role.IDENTIFIER
-  else -> null // WhitespaceTerminal, and any future terminal types: uncoloured by default
+  // RegexTerminal (free-form names/strings: Description=, interface names, ...) and whitespace stay
+  // uncoloured by default — they keep the editor's normal value colour. The IDENTIFIER role is still
+  // available for grammars that opt in explicitly via Labeled (e.g. a single-token field like User=).
+  else -> null
 }
 
 private fun Array<out String>.allPunctuation(): Boolean =

--- a/src/test/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/semanticdata/optionvalues/grammar/ColoringTest.kt
+++ b/src/test/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/semanticdata/optionvalues/grammar/ColoringTest.kt
@@ -14,7 +14,7 @@ class ColoringTest {
     assertEquals(Role.ENUM, defaultRole(FlexibleLiteralChoiceTerminal("AF_INET", "AF_INET6")))
     assertEquals(Role.OPERATOR, defaultRole(LiteralChoiceTerminal(":")))
     assertEquals(Role.OPERATOR, defaultRole(LiteralChoiceTerminal("~")))
-    assertEquals(Role.IDENTIFIER, defaultRole(RegexTerminal("[a-z]+", "[a-z]+")))
+    assertEquals(null, defaultRole(RegexTerminal("[a-z]+", "[a-z]+"))) // free-form: keeps default value color
     assertEquals(null, defaultRole(WhitespaceTerminal()))
   }
 


### PR DESCRIPTION
## What

The default coloring heuristic mapped `RegexTerminal → IDENTIFIER`, so free-form values — `Description=`, interface names like `Bond=bond1`, etc. — got recolored as identifiers. That felt wrong: those should keep the editor's normal value color. Make `RegexTerminal` **uncolored by default**.

> Stacked on #482 (`issue-345-13`). Effectively walks back the auto-identifier coloring (and the Identifier preview example added in #482).

## Changes

- `defaultRole`: `RegexTerminal` now falls through to `null` (no grammar coloring) — free-form names/strings keep the default value color.
- Color settings: drop the **Identifier (grammar)** descriptor, its demo tag, and the `Description=` example, since nothing uses the `IDENTIFIER` role by default anymore.
- Kept: the `Role.IDENTIFIER` enum and its `GRAMMAR_IDENTIFIER` key, so a grammar can still opt a specific field in via `Labeled(Role.IDENTIFIER, …)` later (e.g. a single-token, can't-be-space-separated field like `User=`) — at which point we'd re-add the descriptor + example.

Enum / Literal / Operator coloring is unchanged. Full suite green.

Refs #467 #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)