### PR TITLE
test: run the unit suite against both validation engines (#467)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,10 @@ jobs:
       matrix:
         distribution: [ 'temurin' ]
         java: [ '21' ]
-    name: Java ${{ matrix.Java }} Build
+        # Run the unit tests against both the original validation engine and the new
+        # list-of-successes engine, in parallel.
+        grammarParseEngine: [ 'false', 'true' ]
+    name: Java ${{ matrix.java }} Build (grammar engine ${{ matrix.grammarParseEngine }})
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v7
@@ -46,10 +49,11 @@ jobs:
           mkdir -p ./build
           docker compose --project-directory ./systemd-build up --build
           ./generate-changelog  > build/CHANGELOG
-          ./gradlew test buildPlugin
+          ./gradlew test buildPlugin -Dsystemd.unit.grammarParseEngine=${{ matrix.grammarParseEngine }}
           ./gradlew --stop
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
         with:
+          check_name: "Unit Test Results (grammar engine ${{ matrix.grammarParseEngine }})"
           junit_files: build/test-results/**/*.xml

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -144,6 +144,10 @@ tasks {
    test {
      testLogging.showExceptions = true
      testLogging.setExceptionFormat("full")
+     // Forward the grammar-engine switch to the forked test JVM so the suite can be run twice:
+     //   ./gradlew test                                          (original validation engine)
+     //   ./gradlew test -Dsystemd.unit.grammarParseEngine=true   (new list-of-successes engine)
+     systemProperty("systemd.unit.grammarParseEngine", System.getProperty("systemd.unit.grammarParseEngine", "false"))
    }
 }
 

--- a/src/main/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/semanticdata/optionvalues/grammar/GrammarOptionValue.kt
+++ b/src/main/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/semanticdata/optionvalues/grammar/GrammarOptionValue.kt
@@ -37,7 +37,7 @@ open class GrammarOptionValue(
   override fun generateProblemDescriptors(property: UnitFilePropertyType, holder: ProblemsHolder) {
     val value = property.valueText ?: return
 
-    if (ExperimentalSettings.getInstance(property.project).state.useGrammarParseEngine) {
+    if (FORCE_PARSE_ENGINE || ExperimentalSettings.getInstance(property.project).state.useGrammarParseEngine) {
       generateProblemDescriptorsViaParse(property, value, holder)
       return
     }
@@ -173,5 +173,15 @@ open class GrammarOptionValue(
 
   companion object {
     private val LOG = Logger.getInstance(SemanticDataRepository::class.java)
+
+    /**
+     * Forces the new list-of-successes engine for validation regardless of the per-project setting,
+     * used to run the whole unit-test suite against it (CI runs the suite twice: once without and
+     * once with -Dsystemd.unit.grammarParseEngine=true). Only the validation engine is forced; the
+     * cosmetic annotators stay on the user flag, so problem counts are unchanged and only exact
+     * error spans/messages can differ between engines.
+     */
+    @JvmField
+    val FORCE_PARSE_ENGINE: Boolean = java.lang.Boolean.getBoolean("systemd.unit.grammarParseEngine")
   }
 }

--- a/src/test/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/inspections/InvalidValueInspectionForCGroupSocketBind.kt
+++ b/src/test/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/inspections/InvalidValueInspectionForCGroupSocketBind.kt
@@ -2,6 +2,7 @@ package net.sjrx.intellij.plugins.systemdunitfiles.inspections
 
 import junit.framework.TestCase
 import net.sjrx.intellij.plugins.systemdunitfiles.AbstractUnitFileTest
+import net.sjrx.intellij.plugins.systemdunitfiles.semanticdata.optionvalues.grammar.GrammarOptionValue
 
 class InvalidValueInspectionForCGroupSocketBindOptionValue : AbstractUnitFileTest() {
 
@@ -133,7 +134,9 @@ class InvalidValueInspectionForCGroupSocketBindOptionValue : AbstractUnitFileTes
     assertSize(1, highlights)
     val info = highlights[0]
     assertStringContains("SocketBindAllow's value does not match the expected format.", info!!.description)
-    TestCase.assertEquals("::tcp", info.text)
+    // The two engines localize this differently: the original highlights from after "ipv6"; the
+    // list-of-successes engine consumes "ipv6:" before getting stuck, so it highlights from there.
+    TestCase.assertEquals(if (GrammarOptionValue.FORCE_PARSE_ENGINE) ":tcp" else "::tcp", info.text)
   }
 
   fun testWeakWarningWhenInvalidPortRangeSpecified() {
@@ -154,6 +157,8 @@ class InvalidValueInspectionForCGroupSocketBindOptionValue : AbstractUnitFileTes
     assertSize(1, highlights)
     val info = highlights[0]
     assertStringContains("SocketBindAllow's value is correctly formatted but seems invalid.", info!!.description)
-    TestCase.assertEquals("-", info.text)
+    // The original engine gives up at the first "-"; the list-of-successes engine parses the whole
+    // range form and points at the out-of-range port "-21485".
+    TestCase.assertEquals(if (GrammarOptionValue.FORCE_PARSE_ENGINE) "-21485" else "-", info.text)
   }
 }


### PR DESCRIPTION
## What

Runs the **whole unit-test suite against both validation engines** — the original `SyntacticMatch`/`SemanticMatch` and the new list-of-successes `parse()` — so the new engine is exercised across *every* grammar before any of this is released, rather than trusted on a handful of e2e tests.

> Stacked on #486 (`issue-345-17`).

## How

- **`GrammarOptionValue.FORCE_PARSE_ENGINE`** — a system property (`-Dsystemd.unit.grammarParseEngine=true`) forces *validation* onto the new engine regardless of the per-project experimental flag. Crucially it forces **only validation** — the cosmetic annotators (coloring, key marker, deprecation, IPv6) stay on the user flag. So problem **counts** are unchanged between engines and only exact error *spans/messages* can differ. That keeps the parity comparison clean (otherwise the cosmetic annotators' `INFORMATION` highlights would break every `assertSize`).
- **`build.gradle.kts`** forwards the property to the forked test JVM. Run locally with:
  ```
  ./gradlew test                                          # original engine
  ./gradlew test -Dsystemd.unit.grammarParseEngine=true   # new engine
  ```
- **CI (`main.yml`)** gains a `grammarParseEngine: [false, true]` matrix dimension — both engines run in parallel, each publishing its own test results. (Mirror this on the Kubernetes jobs by duplicating with the `-D` flag.)

## Result — strong parity signal

The entire suite passes under **both** engines. The *only* test needing engine-aware expectations is `InvalidValueInspectionForCGroupSocketBind`, where the new engine localizes two errors differently (and arguably better):
- `ipv6::tcp` → highlights `:tcp` (after consuming `ipv6:`) vs `::tcp`
- `ipv6:tcp:12--21485` → points at the out-of-range port `-21485` vs the dash `-`

Counts and validity verdicts match everywhere else — i.e. the new engine reproduces the original's validation behavior across all grammars, differing only in where a couple of errors are underlined.

Refs #467

🤖 Generated with [Claude Code](https://claude.com/claude-code)