### PR TITLE
ci: run the new-grammar-engine unit tests in parallel (Jenkins) (#467)

### DIFF
--- a/ci/release.Jenkinsfile
+++ b/ci/release.Jenkinsfile
@@ -332,6 +332,8 @@ pipeline {
       }
     }
     stage("Build") {
+      parallel {
+        stage("Build & Publish") {
       agent {
         kubernetes {
           //cloud 'kubernetes'
@@ -390,6 +392,26 @@ pipeline {
             }
 
             archiveArtifacts artifacts: 'build/distributions/*.zip'
+            archiveArtifacts artifacts: 'build/reports/**'
+          }
+        }
+      }
+        }
+        stage("Unit Tests (new grammar engine)") {
+          agent {
+            kubernetes {
+              defaultContainer 'worker-pod'
+              // language=yaml
+              yaml buildPodDefinition("${env.DOCKER_REGISTRY_PREFIX}/systemd-plugin-build-environment:$buildEnvironmentHash", false, false)
+            }
+          }
+          steps {
+            unstash 'systemd-build-build'
+            unstash 'ubuntu-units'
+            sh("""
+              mkdir -p ./build
+              ./gradlew --no-daemon -I ./build-cache-init.gradle.kts -I ./repo-cache-init.gradle.kts --build-cache test -Dsystemd.unit.grammarParseEngine=true
+              """)
             archiveArtifacts artifacts: 'build/reports/**'
           }
         }


### PR DESCRIPTION
## What

Makes the Jenkins pipeline run the unit suite against **both** validation engines, **in parallel**. The "Build" stage previously only tested the original engine (via the `build` task); now it's a `parallel` block (mirroring the existing `Assemble Metadata` stage):

- **Build & Publish** — the original branch: build + test (original engine) + tag/publish.
- **Unit Tests (new grammar engine)** — a lean branch in **its own Kubernetes pod** running `./gradlew … test -Dsystemd.unit.grammarParseEngine=true`.

Separate pods ⇒ separate workspaces ⇒ no `build/` clobbering, and the two runs are genuinely concurrent (not sequential).

> Stacked on #487 (`issue-345-18`), which added `FORCE_PARSE_ENGINE` and the GitHub Actions matrix. (GitHub Actions matrix legs already run as parallel jobs, so that one's fine; this fixes the Jenkins side you actually rely on.)

## Notes

- The new branch doesn't tag/publish and doesn't need the publish/SSH credentials; it does the same `unstash` of the generated metadata so it can compile, and drops `-PbuildScan` (no scan/auth needed for the parity run).
- Brace balance verified; structure matches the existing `parallel { stage{agent…} stage{agent…} }` pattern in this file. The publish branch's inner indentation is left unchanged to avoid risky reformatting.

Refs #467

🤖 Generated with [Claude Code](https://claude.com/claude-code)