### PR TITLE
feat: grammar validators for MAC / hardware-address directives (#501)

### DIFF
--- a/src/main/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/semanticdata/optionvalues/AiGenerated.kt
+++ b/src/main/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/semanticdata/optionvalues/AiGenerated.kt
@@ -273,6 +273,17 @@ fun getAllAIGeneratedValidators(): Map<Validator, OptionValueInformation> {
     Validator("config_parse_fdname", "0") to ConfigParseFdnameOptionValue() as OptionValueInformation,
     Validator("config_parse_udev_property_name", "0") to ConfigParseUdevPropertyNameOptionValue() as OptionValueInformation,
 
+    // MAC / hardware address directives (#501).
+    Validator("config_parse_hw_addrs", "0") to ConfigParseHwAddrsOptionValue() as OptionValueInformation,
+    Validator("config_parse_hw_addr", "0") to ConfigParseHwAddrOptionValue() as OptionValueInformation,
+    Validator("config_parse_neighbor_section", "NEIGHBOR_LINK_LAYER_ADDRESS") to ConfigParseNeighborLinkLayerAddressOptionValue() as OptionValueInformation,
+    Validator("config_parse_sr_iov_mac", "0") to ConfigParseSrIovMacOptionValue() as OptionValueInformation,
+    Validator("config_parse_fdb_hwaddr", "0") to ConfigParseFdbHwaddrOptionValue() as OptionValueInformation,
+    Validator("config_parse_dhcp_static_lease_hwaddr", "0") to ConfigParseDhcpStaticLeaseHwaddrOptionValue() as OptionValueInformation,
+    Validator("config_parse_netdev_hw_addr", "ETH_ALEN") to ConfigParseNetdevHwAddrOptionValue() as OptionValueInformation,
+    Validator("config_parse_macsec_hw_address", "0") to ConfigParseMacsecHwAddressOptionValue() as OptionValueInformation,
+    Validator("config_parse_ether_addrs", "0") to ConfigParseEtherAddrsOptionValue() as OptionValueInformation,
+
   )
 
   return allValidators

--- a/src/main/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/semanticdata/optionvalues/ai/ConfigParseDhcpStaticLeaseHwaddrOptionValue.kt
+++ b/src/main/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/semanticdata/optionvalues/ai/ConfigParseDhcpStaticLeaseHwaddrOptionValue.kt
@@ -1,0 +1,13 @@
+package net.sjrx.intellij.plugins.systemdunitfiles.semanticdata.optionvalues.ai
+
+import net.sjrx.intellij.plugins.systemdunitfiles.semanticdata.optionvalues.grammar.*
+import net.sjrx.intellij.plugins.systemdunitfiles.semanticdata.optionvalues.SimpleGrammarOptionValues
+
+/**
+ * Validator for [DHCPServerStaticLease] MACAddress= (.network).
+ * C Function: config_parse_dhcp_static_lease_hwaddr -> parse_ether_addr (a single 6-byte Ethernet MAC).
+ */
+class ConfigParseDhcpStaticLeaseHwaddrOptionValue : SimpleGrammarOptionValues(
+    "config_parse_dhcp_static_lease_hwaddr",
+    SequenceCombinator(MAC_ADDRESS, EOF())
+)

--- a/src/main/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/semanticdata/optionvalues/ai/ConfigParseEtherAddrsOptionValue.kt
+++ b/src/main/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/semanticdata/optionvalues/ai/ConfigParseEtherAddrsOptionValue.kt
@@ -1,0 +1,13 @@
+package net.sjrx.intellij.plugins.systemdunitfiles.semanticdata.optionvalues.ai
+
+import net.sjrx.intellij.plugins.systemdunitfiles.semanticdata.optionvalues.grammar.*
+import net.sjrx.intellij.plugins.systemdunitfiles.semanticdata.optionvalues.SimpleGrammarOptionValues
+
+/**
+ * Validator for [MACVLAN] SourceMACAddress= and [MACVTAP] SourceMACAddress= (.netdev).
+ * C Function: config_parse_ether_addrs -> a whitespace-separated list of 6-byte Ethernet MACs.
+ */
+class ConfigParseEtherAddrsOptionValue : SimpleGrammarOptionValues(
+    "config_parse_ether_addrs",
+    SequenceCombinator(MAC_ADDRESS, ZeroOrMore(SequenceCombinator(WhitespaceTerminal(), MAC_ADDRESS)), EOF())
+)

--- a/src/main/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/semanticdata/optionvalues/ai/ConfigParseFdbHwaddrOptionValue.kt
+++ b/src/main/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/semanticdata/optionvalues/ai/ConfigParseFdbHwaddrOptionValue.kt
@@ -1,0 +1,13 @@
+package net.sjrx.intellij.plugins.systemdunitfiles.semanticdata.optionvalues.ai
+
+import net.sjrx.intellij.plugins.systemdunitfiles.semanticdata.optionvalues.grammar.*
+import net.sjrx.intellij.plugins.systemdunitfiles.semanticdata.optionvalues.SimpleGrammarOptionValues
+
+/**
+ * Validator for [BridgeFDB] MACAddress= (.network).
+ * C Function: config_parse_fdb_hwaddr -> parse_ether_addr (a single 6-byte Ethernet MAC).
+ */
+class ConfigParseFdbHwaddrOptionValue : SimpleGrammarOptionValues(
+    "config_parse_fdb_hwaddr",
+    SequenceCombinator(MAC_ADDRESS, EOF())
+)

--- a/src/main/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/semanticdata/optionvalues/ai/ConfigParseHwAddrOptionValue.kt
+++ b/src/main/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/semanticdata/optionvalues/ai/ConfigParseHwAddrOptionValue.kt
@@ -1,0 +1,14 @@
+package net.sjrx.intellij.plugins.systemdunitfiles.semanticdata.optionvalues.ai
+
+import net.sjrx.intellij.plugins.systemdunitfiles.semanticdata.optionvalues.grammar.*
+import net.sjrx.intellij.plugins.systemdunitfiles.semanticdata.optionvalues.SimpleGrammarOptionValues
+
+/**
+ * Validator for [Link] MACAddress= (.network, .link).
+ * C Function: config_parse_hw_addr (ltype 0) -> parse_hw_addr_full(expected_len = 0): a single 4/6/16/20-byte
+ * hardware address in colon/hyphen/dot notation, or an IPv4/IPv6 address literal.
+ */
+class ConfigParseHwAddrOptionValue : SimpleGrammarOptionValues(
+    "config_parse_hw_addr",
+    SequenceCombinator(HARDWARE_ADDRESS, EOF())
+)

--- a/src/main/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/semanticdata/optionvalues/ai/ConfigParseHwAddrsOptionValue.kt
+++ b/src/main/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/semanticdata/optionvalues/ai/ConfigParseHwAddrsOptionValue.kt
@@ -1,0 +1,14 @@
+package net.sjrx.intellij.plugins.systemdunitfiles.semanticdata.optionvalues.ai
+
+import net.sjrx.intellij.plugins.systemdunitfiles.semanticdata.optionvalues.grammar.*
+import net.sjrx.intellij.plugins.systemdunitfiles.semanticdata.optionvalues.SimpleGrammarOptionValues
+
+/**
+ * Validator for [Match] MACAddress= and [Match] PermanentMACAddress= (.network, .link).
+ * C Function: config_parse_hw_addrs (ltype 0) -> a whitespace-separated list of hardware addresses, each
+ * a 4/6/16/20-byte address in colon/hyphen/dot notation, or an IPv4/IPv6 address literal.
+ */
+class ConfigParseHwAddrsOptionValue : SimpleGrammarOptionValues(
+    "config_parse_hw_addrs",
+    SequenceCombinator(HARDWARE_ADDRESS, ZeroOrMore(SequenceCombinator(WhitespaceTerminal(), HARDWARE_ADDRESS)), EOF())
+)

--- a/src/main/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/semanticdata/optionvalues/ai/ConfigParseMacsecHwAddressOptionValue.kt
+++ b/src/main/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/semanticdata/optionvalues/ai/ConfigParseMacsecHwAddressOptionValue.kt
@@ -1,0 +1,13 @@
+package net.sjrx.intellij.plugins.systemdunitfiles.semanticdata.optionvalues.ai
+
+import net.sjrx.intellij.plugins.systemdunitfiles.semanticdata.optionvalues.grammar.*
+import net.sjrx.intellij.plugins.systemdunitfiles.semanticdata.optionvalues.SimpleGrammarOptionValues
+
+/**
+ * Validator for [MACsecReceiveChannel] MACAddress= and [MACsecReceiveAssociation] MACAddress= (.netdev).
+ * C Function: config_parse_macsec_hw_address -> parse_ether_addr (a single 6-byte Ethernet MAC).
+ */
+class ConfigParseMacsecHwAddressOptionValue : SimpleGrammarOptionValues(
+    "config_parse_macsec_hw_address",
+    SequenceCombinator(MAC_ADDRESS, EOF())
+)

--- a/src/main/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/semanticdata/optionvalues/ai/ConfigParseNeighborLinkLayerAddressOptionValue.kt
+++ b/src/main/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/semanticdata/optionvalues/ai/ConfigParseNeighborLinkLayerAddressOptionValue.kt
@@ -1,0 +1,14 @@
+package net.sjrx.intellij.plugins.systemdunitfiles.semanticdata.optionvalues.ai
+
+import net.sjrx.intellij.plugins.systemdunitfiles.semanticdata.optionvalues.grammar.*
+import net.sjrx.intellij.plugins.systemdunitfiles.semanticdata.optionvalues.SimpleGrammarOptionValues
+
+/**
+ * Validator for [Neighbor] LinkLayerAddress= (and the deprecated [Neighbor] MACAddress= alias) (.network).
+ * C Function: config_parse_neighbor_section (ltype NEIGHBOR_LINK_LAYER_ADDRESS) -> config_parse_hw_addr with
+ * expected_len = 0: a single 4/6/16/20-byte hardware address, or an IPv4/IPv6 address literal.
+ */
+class ConfigParseNeighborLinkLayerAddressOptionValue : SimpleGrammarOptionValues(
+    "config_parse_neighbor_section",
+    SequenceCombinator(HARDWARE_ADDRESS, EOF())
+)

--- a/src/main/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/semanticdata/optionvalues/ai/ConfigParseNetdevHwAddrOptionValue.kt
+++ b/src/main/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/semanticdata/optionvalues/ai/ConfigParseNetdevHwAddrOptionValue.kt
@@ -1,0 +1,13 @@
+package net.sjrx.intellij.plugins.systemdunitfiles.semanticdata.optionvalues.ai
+
+import net.sjrx.intellij.plugins.systemdunitfiles.semanticdata.optionvalues.grammar.*
+import net.sjrx.intellij.plugins.systemdunitfiles.semanticdata.optionvalues.SimpleGrammarOptionValues
+
+/**
+ * Validator for [NetDev] MACAddress= and [Peer] MACAddress= (.netdev).
+ * C Function: config_parse_netdev_hw_addr (ltype ETH_ALEN) -> a single 6-byte Ethernet MAC.
+ */
+class ConfigParseNetdevHwAddrOptionValue : SimpleGrammarOptionValues(
+    "config_parse_netdev_hw_addr",
+    SequenceCombinator(MAC_ADDRESS, EOF())
+)

--- a/src/main/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/semanticdata/optionvalues/ai/ConfigParseSrIovMacOptionValue.kt
+++ b/src/main/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/semanticdata/optionvalues/ai/ConfigParseSrIovMacOptionValue.kt
@@ -1,0 +1,13 @@
+package net.sjrx.intellij.plugins.systemdunitfiles.semanticdata.optionvalues.ai
+
+import net.sjrx.intellij.plugins.systemdunitfiles.semanticdata.optionvalues.grammar.*
+import net.sjrx.intellij.plugins.systemdunitfiles.semanticdata.optionvalues.SimpleGrammarOptionValues
+
+/**
+ * Validator for [SR-IOV] MACAddress= (.network, .link).
+ * C Function: config_parse_sr_iov_mac -> parse_ether_addr (a single 6-byte Ethernet MAC).
+ */
+class ConfigParseSrIovMacOptionValue : SimpleGrammarOptionValues(
+    "config_parse_sr_iov_mac",
+    SequenceCombinator(MAC_ADDRESS, EOF())
+)

--- a/src/main/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/semanticdata/optionvalues/grammar/Combinators.kt
+++ b/src/main/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/semanticdata/optionvalues/grammar/Combinators.kt
@@ -107,3 +107,39 @@ var IPV4_ADDR_PREFIX_LIST = SequenceCombinator(IPV4_ADDR_AND_PREFIX_OR_SPECIAL, 
 var IPV6_ADDR_PREFIX_LIST = SequenceCombinator(IPV6_ADDR_AND_PREFIX_OR_SPECIAL, ZeroOrMore(SequenceCombinator(WhitespaceTerminal(), IPV6_ADDR_AND_PREFIX_OR_SPECIAL)))
 
 
+// ---------------------------------------------------------------------------------------------------
+// Hardware / MAC addresses (systemd src/basic/ether-addr-util.c). systemd's parse_hw_addr_full accepts
+// three separator styles for the raw hex form:
+//   colon / hyphen — 1-byte fields (1-2 hex digits each):   00:11:22:33:44:55  /  00-11-22-33-44-55
+//   dot            — 2-byte fields (1-4 hex digits each):    0011.2233.4455
+val HYPHEN = LiteralChoiceTerminal("-")
+private val HW_ADDR_BYTE = RegexTerminal("[0-9a-fA-F]{1,2}", "[0-9a-fA-F]{1,2}")   // one 1-byte field
+private val HW_ADDR_WORD = RegexTerminal("[0-9a-fA-F]{1,4}", "[0-9a-fA-F]{1,4}")   // one 2-byte field
+
+// [count] groups of [group] separated by [sep]:  group (sep group){count-1}.
+private fun hwAddrGroups(group: Combinator, sep: Combinator, count: Int): Combinator =
+  SequenceCombinator(group, Repeat(SequenceCombinator(sep, group), count - 1, count - 1))
+
+// A 6-byte Ethernet MAC address, i.e. systemd parse_ether_addr (expected_len == ETH_ALEN). Used by
+// SR-IOV=, BridgeFDB=, DHCPServerStaticLease=, MACsec*=, NetDev/Peer= and MACVLAN/MACVTAP source.
+val MAC_ADDRESS = Labeled(Role.LITERAL, AlternativeCombinator(
+  hwAddrGroups(HW_ADDR_BYTE, COLON, 6),
+  hwAddrGroups(HW_ADDR_BYTE, HYPHEN, 6),
+  hwAddrGroups(HW_ADDR_WORD, DOT, 3),
+))
+
+// A hardware address as accepted by parse_hw_addr_full with expected_len == 0 (Match=, Link=,
+// Neighbor.LinkLayerAddress=). Besides 6-byte MACs this also accepts 4-, 16- and 20-byte (Infiniband)
+// hardware addresses, and — because the parser first tries in_addr_from_string — plain IPv4 and IPv6
+// address literals. colon/hyphen use 1-byte fields (4/6/16/20 groups); dot uses 2-byte fields
+// (2/3/8/10 groups). Longest group counts come first so the classic (first-full-match) matcher never
+// stops on a shorter prefix.
+val HARDWARE_ADDRESS = Labeled(Role.LITERAL, AlternativeCombinator(
+  IPV6_ADDR,
+  IPV4_ADDR,
+  hwAddrGroups(HW_ADDR_BYTE, COLON, 20), hwAddrGroups(HW_ADDR_BYTE, COLON, 16), hwAddrGroups(HW_ADDR_BYTE, COLON, 6), hwAddrGroups(HW_ADDR_BYTE, COLON, 4),
+  hwAddrGroups(HW_ADDR_BYTE, HYPHEN, 20), hwAddrGroups(HW_ADDR_BYTE, HYPHEN, 16), hwAddrGroups(HW_ADDR_BYTE, HYPHEN, 6), hwAddrGroups(HW_ADDR_BYTE, HYPHEN, 4),
+  hwAddrGroups(HW_ADDR_WORD, DOT, 10), hwAddrGroups(HW_ADDR_WORD, DOT, 8), hwAddrGroups(HW_ADDR_WORD, DOT, 3), hwAddrGroups(HW_ADDR_WORD, DOT, 2),
+))
+
+

--- a/src/main/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/semanticdata/optionvalues/grammar/Combinators.kt
+++ b/src/main/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/semanticdata/optionvalues/grammar/Combinators.kt
@@ -128,18 +128,26 @@ val MAC_ADDRESS = Labeled(Role.LITERAL, AlternativeCombinator(
   hwAddrGroups(HW_ADDR_WORD, DOT, 3),
 ))
 
-// A hardware address as accepted by parse_hw_addr_full with expected_len == 0 (Match=, Link=,
-// Neighbor.LinkLayerAddress=). Besides 6-byte MACs this also accepts 4-, 16- and 20-byte (Infiniband)
-// hardware addresses, and — because the parser first tries in_addr_from_string — plain IPv4 and IPv6
-// address literals. colon/hyphen use 1-byte fields (4/6/16/20 groups); dot uses 2-byte fields
-// (2/3/8/10 groups). Longest group counts come first so the classic (first-full-match) matcher never
-// stops on a shorter prefix.
-val HARDWARE_ADDRESS = Labeled(Role.LITERAL, AlternativeCombinator(
-  IPV6_ADDR,
-  IPV4_ADDR,
+// The raw hex forms of a hardware address (colon/hyphen use 1-byte fields → 4/6/16/20 groups; dot uses
+// 2-byte fields → 2/3/8/10 groups). Longest group counts come first so the classic (first-full-match)
+// matcher never stops on a shorter prefix. Wrapped once so the whole address reads as a single literal
+// span rather than per-field.
+private val RAW_HARDWARE_ADDRESS = Labeled(Role.LITERAL, AlternativeCombinator(
   hwAddrGroups(HW_ADDR_BYTE, COLON, 20), hwAddrGroups(HW_ADDR_BYTE, COLON, 16), hwAddrGroups(HW_ADDR_BYTE, COLON, 6), hwAddrGroups(HW_ADDR_BYTE, COLON, 4),
   hwAddrGroups(HW_ADDR_BYTE, HYPHEN, 20), hwAddrGroups(HW_ADDR_BYTE, HYPHEN, 16), hwAddrGroups(HW_ADDR_BYTE, HYPHEN, 6), hwAddrGroups(HW_ADDR_BYTE, HYPHEN, 4),
   hwAddrGroups(HW_ADDR_WORD, DOT, 10), hwAddrGroups(HW_ADDR_WORD, DOT, 8), hwAddrGroups(HW_ADDR_WORD, DOT, 3), hwAddrGroups(HW_ADDR_WORD, DOT, 2),
 ))
+
+// A hardware address as accepted by parse_hw_addr_full with expected_len == 0 (Match=, Link=,
+// Neighbor.LinkLayerAddress=). Besides 6-byte MACs it accepts 4-, 16- and 20-byte (Infiniband)
+// hardware addresses, and — because the parser first tries in_addr_from_string — plain IPv4 and IPv6
+// address literals. IPV4_ADDR / IPV6_ADDR are already Labeled (IPv6 also carries SemanticTag.IPV6), so
+// they sit alongside the wrapped raw forms rather than inside a second wrapper — a whole-alternation
+// Labeled would emit a redundant second literal region over an IP literal's span.
+val HARDWARE_ADDRESS = AlternativeCombinator(
+  IPV6_ADDR,
+  IPV4_ADDR,
+  RAW_HARDWARE_ADDRESS,
+)
 
 

--- a/src/test/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/inspections/ai/MacAddressInspectionTest.kt
+++ b/src/test/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/inspections/ai/MacAddressInspectionTest.kt
@@ -1,0 +1,79 @@
+package net.sjrx.intellij.plugins.systemdunitfiles.inspections.ai
+
+import net.sjrx.intellij.plugins.systemdunitfiles.AbstractUnitFileTest
+import net.sjrx.intellij.plugins.systemdunitfiles.inspections.InvalidValueInspection
+import org.junit.Test
+
+/**
+ * End-to-end (default/classic engine) wiring tests for the MAC / hardware-address validators (#501):
+ * each directive resolves to its grammar validator, accepts a well-formed value, and flags a bad one.
+ * The grammar itself is covered in depth by MacAddressGrammarTest; this proves the section/key -> parser
+ * mapping and that the grammar also matches under the original SyntacticMatch/SemanticMatch path.
+ */
+class MacAddressInspectionTest : AbstractUnitFileTest() {
+
+  private fun highlights(fileName: String, text: String): Int {
+    setupFileInEditor(fileName, text)
+    enableInspection(InvalidValueInspection::class.java)
+    return myFixture.doHighlighting().size
+  }
+
+  // A well-formed value must produce no InvalidValue highlights.
+  private fun assertAccepted(fileName: String, text: String) = assertEquals(0, highlights(fileName, text))
+
+  // A malformed value must be flagged. The classic path can report a partial match as more than one
+  // region, so we only require "at least one" here; MacAddressGrammarTest pins the new-engine outcome.
+  private fun assertRejected(fileName: String, text: String) = assertTrue(highlights(fileName, text) >= 1)
+
+  @Test
+  fun testMatchMacAddressListAcceptsMacsAndIpLiterals() {
+    // config_parse_hw_addrs: whitespace-separated hardware addresses, IP literals allowed.
+    assertAccepted("f.network", "[Match]\nMACAddress=00:11:22:33:44:55 aa-bb-cc-dd-ee-ff 192.168.1.1\n")
+    assertAccepted("f.network", "[Match]\nPermanentMACAddress=0011.2233.4455\n")
+    assertRejected("f.network", "[Match]\nMACAddress=zz:zz:zz:zz:zz:zz\n")
+  }
+
+  @Test
+  fun testLinkMacAddressAcceptsIpLiteralButNotBadLength() {
+    // config_parse_hw_addr (expected_len == 0): single hardware address or IP literal.
+    assertAccepted("f.network", "[Link]\nMACAddress=2001:db8::1\n")
+    assertAccepted("f.link", "[Link]\nMACAddress=00:11:22:33:44:55\n")
+    assertRejected("f.network", "[Link]\nMACAddress=00:11:22\n")
+  }
+
+  @Test
+  fun testNeighborLinkLayerAddress() {
+    // config_parse_neighbor_section / NEIGHBOR_LINK_LAYER_ADDRESS -> hardware address or IP literal.
+    assertAccepted("f.network", "[Neighbor]\nLinkLayerAddress=192.168.1.1\n")
+    assertRejected("f.network", "[Neighbor]\nLinkLayerAddress=nonsense\n")
+  }
+
+  @Test
+  fun testSrIovMacRejectsIpLiteral() {
+    // config_parse_sr_iov_mac -> strict 6-byte MAC; an IP literal is invalid here.
+    assertAccepted("f.link", "[SR-IOV]\nMACAddress=00:11:22:33:44:55\n")
+    assertRejected("f.network", "[SR-IOV]\nMACAddress=192.168.1.1\n")
+  }
+
+  @Test
+  fun testBridgeFdbAndDhcpStaticLeaseMac() {
+    assertAccepted("f.network", "[BridgeFDB]\nMACAddress=00-11-22-33-44-55\n")
+    assertRejected("f.network", "[BridgeFDB]\nMACAddress=00:11:22:33\n")
+    assertAccepted("f.network", "[DHCPServerStaticLease]\nMACAddress=de:ad:be:ef:00:01\n")
+  }
+
+  @Test
+  fun testNetdevPeerAndMacsecMac() {
+    // config_parse_netdev_hw_addr (ETH_ALEN) and config_parse_macsec_hw_address -> strict 6-byte MAC.
+    assertAccepted("f.netdev", "[NetDev]\nMACAddress=00:11:22:33:44:55\n")
+    assertRejected("f.netdev", "[NetDev]\nMACAddress=192.168.1.1\n")
+    assertAccepted("f.netdev", "[MACsecReceiveChannel]\nMACAddress=0011.2233.4455\n")
+  }
+
+  @Test
+  fun testMacvlanSourceMacAddressList() {
+    // config_parse_ether_addrs: whitespace-separated list of strict 6-byte MACs (no IP literals).
+    assertAccepted("f.netdev", "[MACVLAN]\nSourceMACAddress=00:11:22:33:44:55 aa:bb:cc:dd:ee:ff\n")
+    assertRejected("f.netdev", "[MACVLAN]\nSourceMACAddress=00:11:22:33:44:55 192.168.1.1\n")
+  }
+}

--- a/src/test/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/inspections/ai/MacAddressIpv6QuickFixTest.kt
+++ b/src/test/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/inspections/ai/MacAddressIpv6QuickFixTest.kt
@@ -1,0 +1,81 @@
+package net.sjrx.intellij.plugins.systemdunitfiles.inspections.ai
+
+import com.intellij.lang.annotation.HighlightSeverity
+import net.sjrx.intellij.plugins.systemdunitfiles.AbstractUnitFileTest
+import net.sjrx.intellij.plugins.systemdunitfiles.inspections.Ipv6CanonicalFormInspection
+import net.sjrx.intellij.plugins.systemdunitfiles.settings.ExperimentalSettings
+import org.junit.Test
+
+/**
+ * A hardware-address field (Match=, Link=) accepts IPv6 literals, and those literals carry the
+ * SemanticTag.IPV6 from the shared IPV6_ADDR combinator — so the RFC 5952 canonicalization inspection
+ * and its quick-fix compose with the new MAC validators (#501). A strict 6-byte MAC field, which does
+ * not accept IP literals, must never be touched.
+ */
+class MacAddressIpv6QuickFixTest : AbstractUnitFileTest() {
+
+  override fun tearDown() {
+    try {
+      ExperimentalSettings.getInstance(project).state.useGrammarParseEngine = false
+    } finally {
+      super.tearDown()
+    }
+  }
+
+  private fun enableNewEngine() {
+    ExperimentalSettings.getInstance(project).state.useGrammarParseEngine = true
+  }
+
+  private fun hasCanonicalWarning() = myFixture.doHighlighting().any {
+    it.severity == HighlightSeverity.WEAK_WARNING && it.description?.contains("canonical form") == true
+  }
+
+  @Test
+  fun testNonCanonicalIpv6InMatchIsFlagged() {
+    enableNewEngine()
+    setupFileInEditor("f.network", "[Match]\nMACAddress=2001:DB8::1\n")
+    enableInspection(Ipv6CanonicalFormInspection::class.java)
+    assertTrue(hasCanonicalWarning())
+  }
+
+  @Test
+  fun testPlainMacIsNotFlagged() {
+    enableNewEngine()
+    setupFileInEditor("f.network", "[Match]\nMACAddress=00:11:22:33:44:55\n")
+    enableInspection(Ipv6CanonicalFormInspection::class.java)
+    assertFalse(hasCanonicalWarning())
+  }
+
+  @Test
+  fun testStrictMacFieldNeverColorsAnIpv6() {
+    // SR-IOV.MACAddress is a strict 6-byte MAC: an IPv6 literal is invalid there and, crucially, is
+    // NOT a labeled IPv6 span, so the canonicalization inspection must not fire.
+    enableNewEngine()
+    setupFileInEditor("f.link", "[SR-IOV]\nMACAddress=2001:DB8::1\n")
+    enableInspection(Ipv6CanonicalFormInspection::class.java)
+    assertFalse(hasCanonicalWarning())
+  }
+
+  @Test
+  fun testQuickFixRewritesSingleIpv6() {
+    enableNewEngine()
+    setupFileInEditor("f.network", "[Link]\nMACAddress=2001:D${COMPLETION_POSITION}B8::1\n")
+    enableInspection(Ipv6CanonicalFormInspection::class.java)
+    myFixture.doHighlighting()
+
+    myFixture.launchAction(myFixture.findSingleIntention("Convert to canonical IPv6"))
+    myFixture.checkResult("[Link]\nMACAddress=2001:db8::1\n")
+  }
+
+  @Test
+  fun testQuickFixRewritesOnlyTheIpv6WithinAList() {
+    // Offset handling: the IPv6 sits after a MAC in a Match= list; only it should be rewritten.
+    enableNewEngine()
+    setupFileInEditor("f.network", "[Match]\nMACAddress=00:11:22:33:44:55 2001:D${COMPLETION_POSITION}B8::1\n")
+    enableInspection(Ipv6CanonicalFormInspection::class.java)
+    myFixture.doHighlighting()
+
+    myFixture.launchAction(myFixture.findSingleIntention("Convert to canonical IPv6"))
+    myFixture.checkResult("[Match]\nMACAddress=00:11:22:33:44:55 2001:db8::1\n")
+  }
+}

--- a/src/test/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/semanticdata/optionvalues/grammar/MacAddressGrammarTest.kt
+++ b/src/test/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/semanticdata/optionvalues/grammar/MacAddressGrammarTest.kt
@@ -1,0 +1,78 @@
+package net.sjrx.intellij.plugins.systemdunitfiles.semanticdata.optionvalues.grammar
+
+import net.sjrx.intellij.plugins.systemdunitfiles.semanticdata.optionvalues.ai.ConfigParseEtherAddrsOptionValue
+import net.sjrx.intellij.plugins.systemdunitfiles.semanticdata.optionvalues.ai.ConfigParseHwAddrOptionValue
+import net.sjrx.intellij.plugins.systemdunitfiles.semanticdata.optionvalues.ai.ConfigParseHwAddrsOptionValue
+import net.sjrx.intellij.plugins.systemdunitfiles.semanticdata.optionvalues.ai.ConfigParseSrIovMacOptionValue
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Grammar-level tests (new list-of-successes engine, #501) for the MAC / hardware-address validators.
+ * Exercises the two syntaxes and — the point the man pages hide — that a hardware-address field
+ * (Match=, Link=) also accepts IPv4/IPv6 literals, while a strict 6-byte MAC field (SR-IOV=) does not.
+ */
+class MacAddressGrammarTest {
+
+  private fun Combinator.accepts(value: String) = validate(value) == ParseOutcome.Valid
+
+  // A single 6-byte Ethernet MAC (config_parse_ether_addr): SR-IOV=, BridgeFDB=, MACsec=, ...
+  private val mac = ConfigParseSrIovMacOptionValue().combinator
+  // A single hardware address, expected_len == 0 (config_parse_hw_addr): Link=, Neighbor=.
+  private val hwAddr = ConfigParseHwAddrOptionValue().combinator
+  // Whitespace-separated hardware-address list (config_parse_hw_addrs): Match=, PermanentMACAddress=.
+  private val hwAddrs = ConfigParseHwAddrsOptionValue().combinator
+  // Whitespace-separated 6-byte MAC list (config_parse_ether_addrs): MACVLAN/MACVTAP SourceMACAddress=.
+  private val macs = ConfigParseEtherAddrsOptionValue().combinator
+
+  @Test
+  fun testSixByteMacAcceptsAllThreeSeparatorStyles() {
+    assertEquals(true, mac.accepts("00:11:22:33:44:55"))  // colon, 1-byte fields
+    assertEquals(true, mac.accepts("00-11-22-33-44-55"))  // hyphen, 1-byte fields
+    assertEquals(true, mac.accepts("0011.2233.4455"))     // dot, 2-byte fields
+    assertEquals(true, mac.accepts("1:2:3:4:5:6"))        // single-hex-digit fields are allowed
+    assertEquals(true, mac.accepts("DE:AD:BE:EF:00:01"))  // uppercase hex
+  }
+
+  @Test
+  fun testSixByteMacRejectsWrongLengthAndIpLiterals() {
+    assertEquals(false, mac.accepts("00:11:22:33"))           // 4 groups, not 6
+    assertEquals(false, mac.accepts("00:11:22:33:44"))        // 5 groups
+    assertEquals(false, mac.accepts("00:11:22:33:44:55:66"))  // 7 groups
+    assertEquals(false, mac.accepts("gg:hh:ii:jj:kk:ll"))     // non-hex
+    assertEquals(false, mac.accepts("192.168.1.1"))           // IPv4 literal is NOT a 6-byte MAC
+    assertEquals(false, mac.accepts("2001:db8::1"))           // nor is an IPv6 literal
+  }
+
+  @Test
+  fun testHardwareAddressAcceptsMacsInfinibandAndIpLiterals() {
+    assertEquals(true, hwAddr.accepts("00:11:22:33:44:55"))                 // 6-byte MAC
+    assertEquals(true, hwAddr.accepts("0011.2233.4455"))                    // 6-byte, dot form
+    assertEquals(true, hwAddr.accepts("01:02:03:04"))                       // 4-byte hw addr
+    assertEquals(true, hwAddr.accepts(List(20) { "aa" }.joinToString(":"))) // 20-byte (Infiniband)
+    assertEquals(true, hwAddr.accepts("192.168.1.1"))                       // IPv4 literal
+    assertEquals(true, hwAddr.accepts("2001:db8::1"))                       // IPv6 literal
+    assertEquals(true, hwAddr.accepts("::1"))                               // IPv6 literal, compressed
+  }
+
+  @Test
+  fun testHardwareAddressRejectsInvalidLengthsAndGarbage() {
+    assertEquals(false, hwAddr.accepts("00:11:22:33:44"))       // 5 bytes: not 4/6/16/20
+    assertEquals(false, hwAddr.accepts("00:11:22"))             // 3 bytes
+    assertEquals(false, hwAddr.accepts("192.168.1.256"))        // octet out of range, and not a hw addr
+    assertEquals(false, hwAddr.accepts("hello"))
+  }
+
+  @Test
+  fun testHardwareAddressListMixesFormsAndIpLiterals() {
+    assertEquals(true, hwAddrs.accepts("00:11:22:33:44:55"))
+    assertEquals(true, hwAddrs.accepts("00:11:22:33:44:55 aa-bb-cc-dd-ee-ff 192.168.1.1 2001:db8::1"))
+    assertEquals(false, hwAddrs.accepts("00:11:22:33:44:55 not-a-mac"))
+  }
+
+  @Test
+  fun testSixByteMacListRejectsIpLiterals() {
+    assertEquals(true, macs.accepts("00:11:22:33:44:55 aa:bb:cc:dd:ee:ff"))
+    assertEquals(false, macs.accepts("00:11:22:33:44:55 192.168.1.1")) // list of MACs, no IP literals
+  }
+}

--- a/src/test/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/semanticdata/optionvalues/grammar/MacAddressGrammarTest.kt
+++ b/src/test/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/semanticdata/optionvalues/grammar/MacAddressGrammarTest.kt
@@ -75,4 +75,12 @@ class MacAddressGrammarTest {
     assertEquals(true, macs.accepts("00:11:22:33:44:55 aa:bb:cc:dd:ee:ff"))
     assertEquals(false, macs.accepts("00:11:22:33:44:55 192.168.1.1")) // list of MACs, no IP literals
   }
+
+  @Test
+  fun testAddressColorsAsOneLiteralSpan() {
+    // Both combinators are wrapped in Labeled(Role.LITERAL): the whole address is a single literal
+    // span (not coloured per octet / with the separators as operators).
+    assertEquals(listOf(Region(0, 17, Role.LITERAL)), mac.colorize("00:11:22:33:44:55"))
+    assertEquals(listOf(Region(0, 17, Role.LITERAL)), hwAddr.colorize("00-11-22-33-44-55"))
+  }
 }

--- a/src/test/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/semanticdata/optionvalues/grammar/MacAddressGrammarTest.kt
+++ b/src/test/kotlin/net/sjrx/intellij/plugins/systemdunitfiles/semanticdata/optionvalues/grammar/MacAddressGrammarTest.kt
@@ -78,9 +78,17 @@ class MacAddressGrammarTest {
 
   @Test
   fun testAddressColorsAsOneLiteralSpan() {
-    // Both combinators are wrapped in Labeled(Role.LITERAL): the whole address is a single literal
-    // span (not coloured per octet / with the separators as operators).
+    // Both combinators wrap the raw hex forms in Labeled(Role.LITERAL): the whole address is a single
+    // literal span (not coloured per octet / with the separators as operators).
     assertEquals(listOf(Region(0, 17, Role.LITERAL)), mac.colorize("00:11:22:33:44:55"))
     assertEquals(listOf(Region(0, 17, Role.LITERAL)), hwAddr.colorize("00-11-22-33-44-55"))
+  }
+
+  @Test
+  fun testIpLiteralInHardwareAddressColorsAsOneRegion() {
+    // The raw-hex wrapper is not layered over IPV4_ADDR / IPV6_ADDR (they are already Labeled), so an
+    // IP literal yields exactly one region — its own — carrying the IPv6 tag, not a doubled span.
+    assertEquals(listOf(Region(0, 11, Role.LITERAL, SemanticTag.IPV6)), hwAddr.colorize("2001:db8::1"))
+    assertEquals(listOf(Region(0, 11, Role.LITERAL)), hwAddr.colorize("192.168.1.1"))
   }
 }


### PR DESCRIPTION
Closes #501.

Nine networkd/.link/.netdev directives take a MAC or hardware address but had **no value validator** (the key was recognized, the value accepted unconditionally — they resolved to `NullOptionValue`). This adds grammar-based validators faithful to how systemd actually parses each one, verified against `src/basic/ether-addr-util.c` (v261).

## The two syntaxes
- **`MAC_ADDRESS`** — a 6-byte Ethernet MAC (`parse_ether_addr`): colon `00:11:22:33:44:55`, hyphen `00-11-22-33-44-55`, or dot `0011.2233.4455`.
- **`HARDWARE_ADDRESS`** — `parse_hw_addr_full(expected_len=0)`, the "annoying" one: 4/6/16/20-byte hardware addresses in colon/hyphen (1-byte fields) or dot (2-byte fields) notation, **and** — because the parser tries `in_addr_from_string` first — plain **IPv4/IPv6 literals**. So `Match.MACAddress=2001:db8::1` is valid; a strict MAC field like `SR-IOV.MACAddress=192.168.1.1` is not.

## Directives wired up
| `(parser, ltype)` | Directive(s) | Grammar |
|---|---|---|
| `config_parse_hw_addrs` (0) | `[Match]` MACAddress / PermanentMACAddress | list of hardware address |
| `config_parse_hw_addr` (0) | `[Link]` MACAddress | single hardware address |
| `config_parse_neighbor_section` (`NEIGHBOR_LINK_LAYER_ADDRESS`) | `[Neighbor]` LinkLayerAddress (+ deprecated MACAddress) | single hardware address |
| `config_parse_sr_iov_mac` (0) | `[SR-IOV]` MACAddress | 6-byte MAC |
| `config_parse_fdb_hwaddr` (0) | `[BridgeFDB]` MACAddress | 6-byte MAC |
| `config_parse_dhcp_static_lease_hwaddr` (0) | `[DHCPServerStaticLease]` MACAddress | 6-byte MAC |
| `config_parse_netdev_hw_addr` (`ETH_ALEN`) | `[NetDev]` / `[Peer]` MACAddress | 6-byte MAC |
| `config_parse_macsec_hw_address` (0) | `[MACsecReceiveChannel]` / `[MACsecReceiveAssociation]` MACAddress | 6-byte MAC |
| `config_parse_ether_addrs` (0) | `[MACVLAN]` / `[MACVTAP]` SourceMACAddress | list of 6-byte MAC |

## Notes
- **Purely additive** — these directives had no validator before, so nothing that was valid becomes invalid.
- Not gated behind the experimental flag: like every other grammar validator, it validates via the classic `SyntacticMatch`/`SemanticMatch` path when the flag is off and via the new engine when on. Longest group-count alternatives are ordered first so the classic first-full-match matcher never stops on a shorter prefix.

## Testing
- `MacAddressGrammarTest` — new-engine `validate()` coverage of every separator style, the 4/6/16/20-byte lengths, IPv4/IPv6-literal acceptance for hardware addresses, and their rejection for strict MACs.
- `MacAddressInspectionTest` — classic-engine end-to-end wiring for all nine parsers across `.network`/`.link`/`.netdev`.
- Whole suite green under both engines (`-Dsystemd.unit.grammarParseEngine=true` and default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)